### PR TITLE
Add `describe` to `cv.database`

### DIFF
--- a/doc/news/describe.rst
+++ b/doc/news/describe.rst
@@ -1,0 +1,4 @@
+**Added:**
+
+* Added `cv.database.describe` showing some basic stats of the database.
+* Added `cv.database.materials` showing a list of materials currently in the database.

--- a/doc/usage/database_interactions.md
+++ b/doc/usage/database_interactions.md
@@ -25,10 +25,10 @@ from echemdb.cv.database import Database
 db = Database()
 ```
 
-The number of entries in the databse are
+Show statistics of the databse
 
 ```{code-cell} ipython3
-len(db)
+db.describe()
 ```
 
 You can iterate over these entries

--- a/echemdb/cv/database.py
+++ b/echemdb/cv/database.py
@@ -254,6 +254,7 @@ class Database:
         Return the substrate materials in the database.
 
         EXAMPLES::
+
             >>> database = Database.create_example()
             >>> database.materials()
             ['Ru', 'Cu']

--- a/echemdb/cv/database.py
+++ b/echemdb/cv/database.py
@@ -248,3 +248,46 @@ class Database:
                 f"The database has more than one entry with identifier '{identifier}'."
             )
         return entries[0]
+
+    def materials(self):
+        r"""
+        Return the substrate materials in the database.
+
+        EXAMPLES::
+            >>> database = Database.create_example()
+            >>> database.materials()
+            ['Ru', 'Cu']
+
+        """
+        import pandas as pd
+
+        return list(
+            pd.unique(
+                pd.Series(
+                    [
+                        entry.system.electrodes.working_electrode.material
+                        for entry in self
+                    ]
+                )
+            )
+        )
+
+    def describe(self):
+        r"""
+        Returns some statistics about the database.
+
+        EXAMPLES::
+
+            >>> database = Database.create_example()
+            >>> database.describe() # doctest: +NORMALIZE_WHITESPACE
+            {'number of references': 2,
+            'number of entries': 2,
+            'materials': ['Ru', 'Cu']}
+
+        """
+        stats = {
+            "number of references": len(self.bibliography.entries),
+            "number of entries": len(self),
+            "materials": self.materials(),
+        }
+        return stats

--- a/echemdb/cv/database.py
+++ b/echemdb/cv/database.py
@@ -285,9 +285,8 @@ class Database:
             'materials': ['Ru', 'Cu']}
 
         """
-        stats = {
+        return {
             "number of references": len(self.bibliography.entries),
             "number of entries": len(self),
             "materials": self.materials(),
         }
-        return stats


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test for this change. (Doctests included)

<!--
Please add any other relevant info below:
-->

The describe function returns a number of database stats, such as the length of the database or the types of materials currently in the db.

At least the `materials` function is relevant for https://github.com/echemdb/website/pull/153.

Further implementations can be discussed in echemdb/unitpackage#6.